### PR TITLE
refactor wchar args conversion

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -85,7 +85,7 @@ test {
     if (result.getError()) |err| {
         defer err.deinit();
         std.debug.print("compiler error: {s}\n", .{err.getString()});
-        return;
+        return error.ShaderCompilationFailed;
     }
 
     const object = result.getObject();


### PR DESCRIPTION
Reduces the amount of heap allocations for utf8->utf16 arguments conversion to 2.

Backing storage for the arguments is 4k of memory. Since the type used to hold the utf16 characters is `wchar_t`, the arguments must satisfy `(args_char_count + args_len) * sizeof(wchar_t) <= 4096`. Under Windows this imposes a limit of roughly 2k characters, 1k characters on other platforms. (See [wchar_t](https://en.cppreference.com/w/cpp/language/types#Character_types))

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.