### PR TITLE
Get MSVC builds working; add MSVC build targets that link the dynamic MSVC runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   all:
     needs: draft_release
-    if: false
     strategy:
       matrix:
         target: [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   all:
     needs: draft_release
+    if: false
     strategy:
       matrix:
         target: [
@@ -82,15 +83,18 @@ jobs:
           # 'aarch64-windows-msvc',
         ]
         optimize: [Debug, ReleaseFast]
+        link-mode: ['Static', 'Dynamic']
         include:
           - target: 'x86_64-windows-msvc'
+            link-mode: 'Static'
             cpu: '-Dcpu=x86_64_v2'
             link-flags: ''
             post-build: 'install dxc'
             target-postfix: ''
           - target: 'x86_64-windows-msvc'
+            link-mode: 'Dynamic'
             cpu: '-Dcpu=x86_64_v2'
-            link-flags: '-Dmsvcrt_dynamic'
+            link-flags: '-Dmsvcrt_dynamic -Dskip_executables'
             post-build: ''
             target-postfix: '_Dynamic'
     runs-on: windows-latest
@@ -109,14 +113,14 @@ jobs:
       - name: upload
         run: |
           ZSTD_CLEVEL=19 tar -acf "${TARGET_OPT}_lib.tar.zst" -C zig-out/lib .
-          ZSTD_CLEVEL=19 tar -acf "${TARGET_OPT}_bin.tar.zst" -C zig-out/bin .
+          if [[ "${{ matrix.link-mode }}" == "Static" ]]; then ZSTD_CLEVEL=19 tar -acf "${TARGET_OPT}_bin.tar.zst" -C zig-out/bin . ; fi
           ZSTD_CLEVEL=19 tar -acf "${TARGET_OPT}_lib.tar.gz" -C zig-out/lib .
-          ZSTD_CLEVEL=19 tar -acf "${TARGET_OPT}_bin.tar.gz" -C zig-out/bin .
+          if [[ "${{ matrix.link-mode }}" == "Static" ]]; then ZSTD_CLEVEL=19 tar -acf "${TARGET_OPT}_bin.tar.gz" -C zig-out/bin . ; fi
           export RELEASE="$(date -u +%Y.%m.%d)+$(git rev-parse --short HEAD).${{ github.run_attempt }}"
           gh release upload "$RELEASE" "${TARGET_OPT}_lib.tar.zst"
-          gh release upload "$RELEASE" "${TARGET_OPT}_bin.tar.zst"
+          if [[ "${{ matrix.link-mode }}" == "Static" ]]; then gh release upload "$RELEASE" "${TARGET_OPT}_bin.tar.zst"; fi
           gh release upload "$RELEASE" "${TARGET_OPT}_lib.tar.gz"
-          gh release upload "$RELEASE" "${TARGET_OPT}_bin.tar.gz"
+          if [[ "${{ matrix.link-mode }}" == "Static" ]]; then gh release upload "$RELEASE" "${TARGET_OPT}_bin.tar.gz"; fi
         shell: bash
         env:
           WINDOWS: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,14 @@ jobs:
         include:
           - target: 'x86_64-windows-msvc'
             cpu: '-Dcpu=x86_64_v2'
+            link-flags: ''
+            post-build: 'install dxc'
+            target-postfix: ''
+          - target: 'x86_64-windows-msvc'
+            cpu: '-Dcpu=x86_64_v2'
+            link-flags: '-Dmsvcrt_dynamic'
+            post-build: ''
+            target-postfix: '_Dynamic'
     runs-on: windows-latest
     steps:
       - name: Checkout
@@ -97,7 +105,7 @@ jobs:
           7z x zig.zip
           Add-Content $env:GITHUB_PATH "C:\zig-windows-x86_64-0.14.0-dev.1911+3bf89f55c\"
       - name: build
-        run: zig build -Dfrom_source -Dtarget=${{ matrix.target }} -Doptimize=${{ matrix.optimize }} ${{ matrix.cpu }} install dxc
+        run: zig build -Dfrom_source -Dtarget=${{ matrix.target }} -Doptimize=${{ matrix.optimize }} ${{ matrix.cpu }} ${{ matrix.link-flags }} ${{ matrix.post-build }}
       - name: upload
         run: |
           ZSTD_CLEVEL=19 tar -acf "${TARGET_OPT}_lib.tar.zst" -C zig-out/lib .
@@ -112,7 +120,7 @@ jobs:
         shell: bash
         env:
           WINDOWS: true
-          TARGET_OPT: ${{ matrix.target }}_${{ matrix.optimize }}
+          TARGET_OPT: ${{ matrix.target }}_${{ matrix.optimize }}${{ matrix.target-postfix }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   publish:
     # TODO: re-enable required MSVC builds

--- a/build.zig
+++ b/build.zig
@@ -19,6 +19,7 @@ pub fn build(b: *Build) !void {
     const debug_symbols = b.option(bool, "debug_symbols", "Whether to produce detailed debug symbols (g0) or not. These increase binary size considerably.") orelse false;
     const build_shared = b.option(bool, "shared", "Build dxcompiler shared libraries") orelse false;
     const build_spirv = b.option(bool, "spirv", "Build spir-v compilation support") orelse false;
+    const msvcrt_dynamic = b.option(bool, "msvcrt_dynamic", "Link with the dynamic MSVC runtime") orelse false;
     const skip_executables = b.option(bool, "skip_executables", "Skip building executables") orelse false;
     const skip_tests = b.option(bool, "skip_tests", "Skip building tests") orelse false;
 
@@ -64,7 +65,10 @@ pub fn build(b: *Build) !void {
 
             lib.addCSourceFile(.{
                 .file = b.path("src/mach_dxc.cpp"),
-                .flags = &.{
+                .flags = if (msvcrt_dynamic) &.{
+                    "-fms-extensions", // __uuidof and friends (on non-windows targets)
+                    "-fms-runtime-lib=dll",
+                } else &.{
                     "-fms-extensions", // __uuidof and friends (on non-windows targets)
                 },
             });
@@ -95,6 +99,11 @@ pub fn build(b: *Build) !void {
 
             try cflags.appendSlice(base_flags);
             try cppflags.appendSlice(base_flags);
+
+            if (msvcrt_dynamic) {
+                try cflags.append("-fms-runtime-lib=dll");
+                try cppflags.append("-fms-runtime-lib=dll");
+            }
 
             addConfigHeaders(b, lib);
             addIncludes(b, lib);

--- a/build.zig
+++ b/build.zig
@@ -254,7 +254,7 @@ pub fn build(b: *Build) !void {
 
                         // For some reason, msvc target needs atls.lib to be in the 'zig build' working directory.
                         // Addomg tp the library path like this has no effect:
-                        dxc_exe.addLibraryPath(b.path(lib_dir_path));
+                        dxc_exe.addLibraryPath(.{ .cwd_relative = lib_dir_path });
                         // So instead we must copy the lib into this directory:
                         try std.fs.cwd().copyFile(lib_path, std.fs.cwd(), "atls.lib", .{});
                         try std.fs.cwd().copyFile(pdb_path, std.fs.cwd(), pdb_name, .{});

--- a/msvc.zig
+++ b/msvc.zig
@@ -135,7 +135,7 @@ const RegistryUtf8 = struct {
         const value_utf16le = try registry_utf16le.getString(allocator, subkey_utf16le, value_name_utf16le);
         defer allocator.free(value_utf16le);
 
-        const value_utf8: []u8 = std.unicode.utf16leToUtf8Alloc(allocator, value_utf16le) catch |err| switch (err) {
+        const value_utf8: []u8 = std.unicode.utf16LeToUtf8Alloc(allocator, value_utf16le) catch |err| switch (err) {
             error.OutOfMemory => return error.OutOfMemory,
             else => return error.StringNotFound,
         };
@@ -368,7 +368,7 @@ pub const Windows10Sdk = struct {
                 error.OutOfMemory => return error.OutOfMemory,
             };
 
-            if (path_maybe_with_trailing_slash.len > std.fs.MAX_PATH_BYTES or !std.fs.path.isAbsolute(path_maybe_with_trailing_slash)) {
+            if (path_maybe_with_trailing_slash.len > std.fs.max_path_bytes or !std.fs.path.isAbsolute(path_maybe_with_trailing_slash)) {
                 allocator.free(path_maybe_with_trailing_slash);
                 return error.PathTooLong;
             }
@@ -414,7 +414,7 @@ pub const Windows10Sdk = struct {
 
     /// Check whether this version is enumerated in registry.
     fn isValidVersion(windows10sdk: *const Windows10Sdk) bool {
-        var buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+        var buf: [std.fs.max_path_bytes]u8 = undefined;
         const reg_query_as_utf8 = std.fmt.bufPrint(buf[0..], "{s}\\{s}\\Installed Options", .{ WINDOWS_KIT_REG_KEY, windows10sdk.version }) catch |err| switch (err) {
             error.NoSpaceLeft => return false,
         };
@@ -458,7 +458,7 @@ pub const Windows81Sdk = struct {
 
                 error.OutOfMemory => return error.OutOfMemory,
             };
-            if (path_maybe_with_trailing_slash.len > std.fs.MAX_PATH_BYTES or !std.fs.path.isAbsolute(path_maybe_with_trailing_slash)) {
+            if (path_maybe_with_trailing_slash.len > std.fs.max_path_bytes or !std.fs.path.isAbsolute(path_maybe_with_trailing_slash)) {
                 allocator.free(path_maybe_with_trailing_slash);
                 return error.PathTooLong;
             }
@@ -475,7 +475,7 @@ pub const Windows81Sdk = struct {
         errdefer allocator.free(path);
 
         const version: []const u8 = version81: {
-            var buf: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+            var buf: [std.fs.max_path_bytes]u8 = undefined;
             const sdk_lib_dir_path = std.fmt.bufPrint(buf[0..], "{s}\\Lib\\", .{path}) catch |err| switch (err) {
                 error.NoSpaceLeft => return error.PathTooLong,
             };
@@ -822,7 +822,7 @@ pub const MsvcLibDir = struct {
                 error.OutOfMemory => return error.OutOfMemory,
                 else => continue,
             };
-            if (source_directories_value.len > (std.fs.MAX_PATH_BYTES * 30)) { // note(bratishkaerik): guessing from the fact that on my computer it has 15 pathes and at least some of them are not of max length
+            if (source_directories_value.len > (std.fs.max_path_bytes * 30)) { // note(bratishkaerik): guessing from the fact that on my computer it has 15 pathes and at least some of them are not of max length
                 allocator.free(source_directories_value);
                 continue;
             }
@@ -836,7 +836,7 @@ pub const MsvcLibDir = struct {
         const msvc_dir: []const u8 = msvc_dir: {
             const msvc_include_dir_maybe_with_trailing_slash = try allocator.dupe(u8, source_directories_splitted.first());
 
-            if (msvc_include_dir_maybe_with_trailing_slash.len > std.fs.MAX_PATH_BYTES or !std.fs.path.isAbsolute(msvc_include_dir_maybe_with_trailing_slash)) {
+            if (msvc_include_dir_maybe_with_trailing_slash.len > std.fs.max_path_bytes or !std.fs.path.isAbsolute(msvc_include_dir_maybe_with_trailing_slash)) {
                 allocator.free(msvc_include_dir_maybe_with_trailing_slash);
                 return error.PathNotFound;
             }
@@ -904,7 +904,7 @@ pub const MsvcLibDir = struct {
                     else => break :try_vs7_key,
                 };
 
-                if (path_maybe_with_trailing_slash.len > std.fs.MAX_PATH_BYTES or !std.fs.path.isAbsolute(path_maybe_with_trailing_slash)) {
+                if (path_maybe_with_trailing_slash.len > std.fs.max_path_bytes or !std.fs.path.isAbsolute(path_maybe_with_trailing_slash)) {
                     allocator.free(path_maybe_with_trailing_slash);
                     break :try_vs7_key;
                 }

--- a/msvc/wrl/internal.h
+++ b/msvc/wrl/internal.h
@@ -18,7 +18,7 @@ namespace Microsoft {
 
             typedef int BoolStruct::* BoolType;
 
-            inline void DECLSPEC_NORETURN RaiseException(HRESULT hr, DWORD flags = EXCEPTION_NONCONTINUABLE) throw() {
+            inline void RaiseException(HRESULT hr, DWORD flags = EXCEPTION_NONCONTINUABLE) throw() {
                 ::RaiseException(static_cast<DWORD>(hr), flags, 0, NULL);
             }
 


### PR DESCRIPTION
This PR integrates the changes from https://github.com/hexops/mach-dxcompiler/pull/8 alongside some additional fixes. With these fixes, I am able to build the `windows-msvc` target on my machine.

In addition, this PR adds a new compilation flag (`-Dmsvcrt_dynamic`) that allows for linking the dynamic MSVC runtime (`msvcrt.lib`) rather than the static one (`libcmt.lib`). This is useful if you want to include `machdxcompiler.lib` in a project that already has other libraries linking to `msvcrt.lib`. I have also added CI builds that run with this flag enabled.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.